### PR TITLE
prevent `svc.load_property` from mutating the obj's uri

### DIFF
--- a/lib/ruby_odata/service.rb
+++ b/lib/ruby_odata/service.rb
@@ -472,13 +472,13 @@ class Service
     uri
   end
   def build_add_link_uri(operation)
-    uri = "#{operation.klass.send(:__metadata)[:uri]}"
+    uri = operation.klass.send(:__metadata)[:uri].dup
     uri << "/$links/#{operation.klass_name}"
     uri << "?#{@additional_params.to_query}" unless @additional_params.empty?
     uri
   end
   def build_resource_uri(operation)
-    uri = operation.klass.send(:__metadata)[:uri]
+    uri = operation.klass.send(:__metadata)[:uri].dup
     uri << "?#{@additional_params.to_query}" unless @additional_params.empty?
     uri
   end
@@ -488,7 +488,7 @@ class Service
     uri
   end
   def build_load_property_uri(obj, property)
-    uri = obj.__metadata[:uri]
+    uri = obj.__metadata[:uri].dup
     uri << "/#{property}"
     uri
   end

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -466,6 +466,15 @@ module OData
           category.Products[0].Id.should eq 1
           category.Products[1].Id.should eq 2
         end
+
+        it "should not mutate the object's metadata" do
+          svc = OData::Service.new "http://test.com/test.svc/"
+          svc.Products(1)
+          product = svc.execute.first
+          original_metadata = product.__metadata.to_json
+          svc.load_property(product, "Category")
+          product.__metadata.to_json.should == original_metadata
+        end
       end
 
       describe "find, create, add, update, and delete" do


### PR DESCRIPTION
Currently something like:

```
svc.load_property object, 'Property'
svc.load_property object, 'OtherProperty'
```

Will cause the `OtherProperty` to be loaded off or the uri for `/object_base_uri/Property`.
This patch makes sure no `build_*` operations mutate metadata uri's.
