### PR TITLE
Persists the additional_params for partial calls

### DIFF
--- a/lib/ruby_odata/service.rb
+++ b/lib/ruby_odata/service.rb
@@ -437,7 +437,11 @@ class Service
   def extract_partial(doc)
     next_links = doc.xpath('//atom:link[@rel="next"]', @ds_namespaces)
     @has_partial = next_links.any?
-    @next_uri = next_links[0]['href'] if @has_partial
+    if @has_partial
+      uri = Addressable::URI.parse(next_links[0]['href']) 
+      uri.query_values = uri.query_values.merge @additional_params unless @additional_params.empty?
+      @next_uri = uri.to_s
+    end
   end
 
   def handle_partial

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -377,6 +377,30 @@ module OData
         end
         results.count.should eq 3
       end
+
+      context "with additional_params" do
+        before(:each) do
+          stub_request(:get, "http://test.com/test.svc/$metadata?extra_param=value").
+         with(:headers => {'Accept'=>'*/*; q=0.5, application/xml', 'Accept-Encoding'=>'gzip, deflate', 'User-Agent'=>'Ruby'}).
+         to_return(:status => 200, :body => File.new(File.expand_path("../fixtures/partial/partial_feed_metadata.xml", __FILE__)), :headers => {})
+
+          stub_request(:get, "http://test.com/test.svc/Partials?extra_param=value").
+            with(:headers => {'Accept'=>'*/*; q=0.5, application/xml', 'Accept-Encoding'=>'gzip, deflate'}).
+            to_return(:status => 200, :body => File.new(File.expand_path("../fixtures/partial/partial_feed_part_1.xml", __FILE__)), :headers => {})
+
+          stub_request(:get, "http://test.com/test.svc/Partials?$skiptoken='ERNSH'&extra_param=value").
+            with(:headers => {'Accept'=>'*/*; q=0.5, application/xml', 'Accept-Encoding'=>'gzip, deflate'})
+        end
+
+        it "should persist the additional parameters for the next call" do
+          svc = OData::Service.new("http://test.com/test.svc/", :eager_partial => false, :additional_params => { :extra_param => 'value' })
+          svc.Partials
+          svc.execute
+          svc.next
+          
+          a_request(:get, "http://test.com/test.svc/Partials?$skiptoken='ERNSH'&extra_param=value").should have_been_made
+        end
+      end
     end
 
     describe "link queries" do


### PR DESCRIPTION
I started with the next that was previously used and just added the additional params to it
Used Addressable so I wouldn't check if the query already contains a '?' or not when appending the parameters.
