### PR TITLE
Drop backports dependency

### DIFF
--- a/lib/ruby_odata.rb
+++ b/lib/ruby_odata.rb
@@ -11,7 +11,6 @@ require "rest_client"
 require "nokogiri"
 require "bigdecimal"
 require "bigdecimal/util"
-require "backports"
 require "addressable/uri"
 
 require lib + "/ruby_odata/exceptions"

--- a/ruby_odata.gemspec
+++ b/ruby_odata.gemspec
@@ -14,12 +14,13 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "ruby-odata"
 
+  s.required_ruby_version = '>= 1.9.3'
+
   s.add_dependency("addressable", ">= 2.3.4")
   s.add_dependency("i18n", "~> 0.6.0")
   s.add_dependency("activesupport", ">= 3.0.0")
   s.add_dependency("rest-client", ">= 1.5.1")
   s.add_dependency("nokogiri", ">= 1.4.2")
-  s.add_dependency("backports", ">= 2.3.0")
 
   s.add_development_dependency("rake", "0.9.2")
   s.add_development_dependency("rspec", "~> 2.11.0")


### PR DESCRIPTION
The gem is not tested any more on 1.8 and the version has reached its
end of life any way. Fixes #45.
