### PR TITLE
Reraise errors unless response is defined and present

### DIFF
--- a/lib/ruby_odata/service.rb
+++ b/lib/ruby_odata/service.rb
@@ -374,7 +374,7 @@ class Service
 
   # Handles errors from the OData service
   def handle_exception(e)
-    raise e unless defined? e.response
+    raise e unless defined?(e.response) && e.response != nil
 
     code = e.response[:status]
     error = Nokogiri::XML(e.response[:body])


### PR DESCRIPTION
We encountered a server that was having issues in the SSL layer, which was causing an error `SSLRead() return error -9806` to be thrown. It seems that this error had a `response` accessor defined, but that value was nil. I've changed it so that if that is the case, it re-throws the error as if it were an error with no `response` accessor defined.

We're using it now in our production environment it is working well