### PR TITLE
Use `\A` and `\z` to match beginning and end of string

### DIFF
--- a/lib/ruby_odata/service.rb
+++ b/lib/ruby_odata/service.rb
@@ -101,7 +101,7 @@ class Service
     rescue Exception => e
       handle_exception(e)
     end
-    return Integer(@response.body) if @response.body =~ /^\d+$/
+    return Integer(@response.body) if @response.body =~ /\A\d+\z/
     handle_collection_result(@response.body)
   end
 


### PR DESCRIPTION
Found a strange and awkward bug that would cause the regex `/^\d+$/` to match if anywhere in the response was a string such as `\n12345\n`. It would then try and parse the entire response (an XML doc) into `Integer()`. If we use `\A` and `\z` instead, it'll check the beginning and ends of the string, rather than search for the beginning and ends of a line.