### PR TITLE
Allow reconfiguring Faraday with block and explain NTLM auth.

### DIFF
--- a/lib/ruby_odata.rb
+++ b/lib/ruby_odata.rb
@@ -7,7 +7,6 @@ require "active_support" # Used for serializtion to JSON
 require "active_support/inflector"
 require "active_support/core_ext"
 require "cgi"
-require "excon"
 require "faraday_middleware"
 require "faraday"
 require "nokogiri"

--- a/lib/ruby_odata/resource.rb
+++ b/lib/ruby_odata/resource.rb
@@ -1,46 +1,39 @@
 module OData
   class Resource
-    attr_reader :url, :options, :block
-
-    def initialize(url, options={}, backwards_compatibility=nil, &block)
-      @url = url
-      @block = block
-      @options = options.is_a?(Hash) ? options : { user: options, password: backwards_compatibility }
-
-      @conn = Faraday.new(url: url, ssl: { verify: verify_ssl }) do |faraday|
+    def initialize(url, options={})
+      @conn = Faraday.new(url: url, ssl: { verify: options[:verify_ssl] }) do |faraday|
         faraday.use      :gzip
         faraday.response :raise_error
-        faraday.adapter  :excon
 
-        faraday.options.timeout      = timeout if timeout
-        faraday.options.open_timeout = open_timeout if open_timeout
+        faraday.options.timeout      = options[:timeout] if options[:timeout]
+        faraday.options.open_timeout = options[:open_timeout] if options[:open_timeout]
 
-        faraday.headers = (faraday.headers || {}).merge(@options[:headers] || {})
+        faraday.headers = (faraday.headers || {}).merge(options[:headers] || {})
         faraday.headers = (faraday.headers).merge({
           :accept => '*/*; q=0.5, application/xml',
         })
 
-        faraday.basic_auth user, password if user# this adds to headers so must be behind
-      end
+        faraday.basic_auth options[:user], options[:password] if options[:user] # this adds to headers so must be behind
 
-      @conn.headers[:user_agent] = 'Ruby'
+        yield faraday if block_given?
+      end
     end
 
-    def get(additional_headers={})
+    def get(url, additional_headers={})
       @conn.get do |req|
         req.url url
         req.headers = (headers || {}).merge(additional_headers)
       end
     end
 
-    def head(additional_headers={})
+    def head(url, additional_headers={})
       @conn.head do |req|
         req.url url
         req.headers = (headers || {}).merge(additional_headers)
       end
     end
 
-    def post(payload, additional_headers={})
+    def post(url, payload, additional_headers={})
       @conn.post do |req|
         req.url url
         req.headers = (headers || {}).merge(additional_headers)
@@ -48,7 +41,7 @@ module OData
       end
     end
 
-    def put(payload, additional_headers={})
+    def put(url, payload, additional_headers={})
       @conn.put do |req|
         req.url url
         req.headers = (headers || {}).merge(additional_headers)
@@ -56,7 +49,7 @@ module OData
       end
     end
 
-    def patch(payload, additional_headers={})
+    def patch(url, payload, additional_headers={})
       @conn.patch do |req|
         req.url url
         req.headers = (headers || {}).merge(additional_headers)
@@ -64,84 +57,15 @@ module OData
       end
     end
 
-    def delete(additional_headers={})
+    def delete(url, additional_headers={})
       @conn.delete do |req|
         req.url url
         req.headers = (headers || {}).merge(additional_headers)
       end
     end
 
-    def to_s
-      url
-    end
-
-    def user
-      options[:user]
-    end
-
-    def password
-      options[:password]
-    end
-
-    def verify_ssl
-      options[:verify_ssl]
-    end
-
     def headers
       @conn.headers || {}
-    end
-
-    def timeout
-      options[:timeout]
-    end
-
-    def open_timeout
-      options[:open_timeout]
-    end
-
-    # Construct a subresource, preserving authentication.
-    #
-    # Example:
-    #
-    #   site = RestClient::Resource.new('http://example.com', 'adam', 'mypasswd')
-    #   site['posts/1/comments'].post 'Good article.', :content_type => 'text/plain'
-    #
-    # This is especially useful if you wish to define your site in one place and
-    # call it in multiple locations:
-    #
-    #   def orders
-    #     RestClient::Resource.new('http://example.com/orders', 'admin', 'mypasswd')
-    #   end
-    #
-    #   orders.get                     # GET http://example.com/orders
-    #   orders['1'].get                # GET http://example.com/orders/1
-    #   orders['1/items'].delete       # DELETE http://example.com/orders/1/items
-    #
-    # Nest resources as far as you want:
-    #
-    #   site = RestClient::Resource.new('http://example.com')
-    #   posts = site['posts']
-    #   first_post = posts['1']
-    #   comments = first_post['comments']
-    #   comments.post 'Hello', :content_type => 'text/plain'
-    #
-    def [](suburl, &new_block)
-      case
-        when block_given? then self.class.new(concat_urls(url, suburl), options, &new_block)
-        when block        then self.class.new(concat_urls(url, suburl), options, &block)
-      else
-        self.class.new(concat_urls(url, suburl), options)
-      end
-    end
-
-    def concat_urls(url, suburl) # :nodoc:
-      url = url.to_s
-      suburl = suburl.to_s
-      if url.slice(-1, 1) == '/' or suburl.slice(0, 1) == '/'
-        url + suburl
-      else
-        "#{url}/#{suburl}"
-      end
     end
 
     def prepare_payload payload

--- a/ruby_odata.gemspec
+++ b/ruby_odata.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |s|
   s.add_dependency("addressable", ">= 2.3.4")
   s.add_dependency("i18n", ">= 0.7.0")
   s.add_dependency("activesupport", ">= 3.0.0")
-  s.add_dependency("excon", "~> 0.45.3")
   s.add_dependency("faraday_middleware")
   s.add_dependency("faraday", "~> 0.9.1")
   s.add_dependency("nokogiri", ">= 1.4.2")


### PR DESCRIPTION
Updates the OData Service to allow passing it a block that is called when Faraday is initialised. This allows more advanced configurations such as NTLM auth, of which I give an example in the README. (Since NTLM auth with Faraday is undocumented, my way of using it might not be the best. Therefore, this code is kept outside the OData library, so other ways of reconfiguring Faraday are also possible.)